### PR TITLE
[Week07] 이재원

### DIFF
--- a/jaewon/Chapter.md
+++ b/jaewon/Chapter.md
@@ -4,3 +4,4 @@
 [4장: 구독을 이용한 모듈 상태 공유](https://northern-goldfish-40c.notion.site/4-10683788eeef80d18a6dcbc8ccd545ff)
 [5장: 리액트 컨텍스트와 구독을 이용한 컴포넌트 상태 공유](https://northern-goldfish-40c.notion.site/5-56c65489806f460396f3377f30820b96?pvs=74)
 [6장: 전역 상태 관리 라이브러리 소개](https://northern-goldfish-40c.notion.site/6-10b83788eeef80e2b68edb7fa7ac7443?pvs=74)
+[7장: 사용 사례 시나리오 1: Zustand](https://northern-goldfish-40c.notion.site/7-1-Zustand-11383788eeef80e1bf27dcc14f00da99?pvs=74)


### PR DESCRIPTION
크게 흥미가 가는 부분은 없었습니다. 지극히 개인적인 의견으로 query-cache의 개념이 등장한 이후로부터는 프론트엔드에서 "전역 상태"의 비중이 많이 줄었다고 생각합니다. redis와 같은 캐싱 프레임워크가 점점 인기를 끌어가며 redis 공화국이라 불릴 날이 머지 않았다고 느끼는 요즘이기에 더욱 그러한가 봅니다. 그런 의미에서 사실 전역 상태 라이브러리를 어떻게 사용하냐? 보다는 어떤 데이터를 전역 상태로 관리할 것인가? 혹은 전역 상태를 어떤 구조와 전략으로 접근할 것인가? 에 더 방점을 찍게 되는 것 같습니다. 뭔가 변명같지만 이러한 생각 아래에 흥미를 느끼지 못하였기에 글이 짧아졌음을 고개를 빳빳이 들고 죄송하단 말씀을 드리는 바입니다.

사실 최근 들어 흥미로운 고민에 빠져있습니다. 서론이 좀 긴 것에 미리 양해의 말씀을 드립니다. 7장과 관련된 토론주제라기 보다 3장과 관련된 토론주제에 가깝습니다. 최근들어 찾게 된 [블로그](https://www.advanced-react.com/)인데, [React re-renders guide](https://www.developerway.com/posts/react-re-renders-guide)라는 아티클을 보고 이마를 탁 쳤습니다. 특히 HoC + useContext + memo의 조합으로 Conext consumer의 리랜더링을 방지하는 파트는 평소에 충분히 생각해볼 수 있을 법한 패틴어이었는데, 떠오르지 못한 것이 아쉬웠습니다. 개인적으로 저자가 제시했던 Provider를 state의 수만큼 중첩하고 reduceRight를 쓰는 것보단 좋아보였습니다.

개인적으론 감명받아서 번역 작업도 진행해도 되냐고 물어보고 이 아티클에서 제시하는 패턴을 사내에 공유했습니다. 물론, 공유라 해봤자 저를 포함해서 두명의 FE 개발자뿐이지만요. 아무튼 피드백을 받았는데 들려온 답변은 "이렇게까지 리랜더링을 방지해야 하는 이유가 무엇인가?" 였습니다. 보다 엄밀히 말하여 "커밋을 하지 않는 리랜더링은 방치해도 괜찮지 않냐?" 입니다. 모두 잘 아시겠지만 react의 리랜더링은 크게 2가지 프로세스로 이루어집니다. 첫번째는 리랜더링 트리거에 해당하는 조건 변경을 감지하는 리랜더링 파트이고, 두번째는 virtual-dom과 real-dom을 통해 변경점을 찾고 이를 dom에 반영하는 commit파트입니다. 즉 commit까지 이어지지 않는 re-rendering은 조금 덜 신경을 써도 되지 않겠느냐. 바꿔 말하여 오히려 너무 코드만 복잡해지지 않을까하는 우려섞인 목소리였습니다.

사실.. 저도 이 이야기를 듣고 "ㅇㅇ 공감" 이라고 답변할 수 밖에 없었습니다. 리랜더링이 얼마나 많은 코스트가 지불되는지, 그리고 그 코스트 중 얼마나 diff 알고리즘의 수행에 할당되는지, 얼마나 mount 작업에 할당되는지 잘 몰랐기 때문입니다. 이와 관련하여 지식을 보충하려해도 diff 수행보다 mount가 비싸단 이야기만 있을 뿐 만족스런 결과를 찾지 못했습니다. 사실 re-render는 줄이면 줄일수록 좋다는 알 수 없는 강박에 사로 잡혀있었다는 의심을 스스로 하게 되는 지난 한주였습니다. 이런 제 경험을 공유드리면서 "commit을 동반하지 않는 re-render는 프론트가 어느정도의 task로 관리하여야 하는가?" 라는 토론 주제를 투척해봅니다. 